### PR TITLE
fix loading RGB-D data

### DIFF
--- a/scripts/dataset.py
+++ b/scripts/dataset.py
@@ -69,9 +69,7 @@ class CocoSegmentationAlb(CocoDetection):
         # Extract depth channel from masks and concatenate to image
         if self.depth_dir is not None:
             _, h, w = img.shape
-            rgbd = torch.zeros(size=(4, h, w), dtype=torch.float32)
-            rgbd[:3,:,:] = img
-            rgbd[3,:,:] = masks.pop(-1)
-            img = rgbd
+            depth = masks.pop(-1)
+            img = torch.cat([img, torch.unsqueeze(depth, 0)], dim=0)
 
         return img, target

--- a/scripts/dataset.py
+++ b/scripts/dataset.py
@@ -71,7 +71,7 @@ class CocoSegmentationAlb(CocoDetection):
             _, h, w = img.shape
             rgbd = torch.zeros(size=(4, h, w), dtype=torch.float32)
             rgbd[:3,:,:] = img
-            rgbd[3,:,:] = torch.from_numpy(masks.pop(-1))
+            rgbd[3,:,:] = masks.pop(-1)
             img = rgbd
 
         return img, target


### PR DESCRIPTION
Apparently, upgrading albumentations from 1.1.0 to 1.3.0 broke loading RGB-D data.

In albumentations v1.2.0 and later, ToTensorV2 supports converting both image and masks to Tensors. Because we feed depth data as masks to the transforms, the transformed depth data is now Tenosor.

This PR fixes combining image data and depth data.